### PR TITLE
Added Google Benchmark as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "benchmark"]
+	path = benchmark
+	url = https://github.com/google/benchmark.git

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ Attached Jupyter notebook with basic analysis
 
 To build
 
+```bash
+git clone --recursive https://github.com/phejet/benchmarkingcpp_games_trading.git
+cd benchmarkingcpp_games_trading
 mkdir build
 cd build
 cmake ../
 make
+```
+


### PR DESCRIPTION
mkdir build; cd build; cmake .. ; make  was failing from benchmark being an empty directory. 

I added Google Benchmark as a submodule and updated the README.

